### PR TITLE
Move Client-Only Mixin

### DIFF
--- a/src/main/resources/horsebuff.mixins.json
+++ b/src/main/resources/horsebuff.mixins.json
@@ -4,7 +4,6 @@
   "package": "net.F53.HorseBuff.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "Client.InventoryAccessor",
     "PortalHorse.OnCollideEnd",
     "PortalHorse.OnCollideNether",
     "PortalHorse.TickNether",
@@ -16,6 +15,7 @@
     "Server.StepHeight"
   ],
   "client": [
+    "Client.InventoryAccessor",
     "Client.HeadPitchOffset",
     "Client.HorseRenderer",
     "Client.JebHorseTintable",


### PR DESCRIPTION
Resolves `@Mixin target net.minecraft.class_310 was not found horsebuff.mixins.json:Client.InventoryAccessor from mod horsebuff` when installed on a server.