### PR TITLE
Bump to 1.20.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
-loader_version=0.15.0
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.3
 
 # Mod Properties
 mod_version = 2.1.3
@@ -14,7 +14,7 @@ maven_group = com.HorseBuff
 archives_base_name = HorseBuff
 
 # Dependencies
-fabric_version=0.91.1+1.20.2
-cloth_config_version=12.0.111
-mod_menu_version=8.0.0
+fabric_version=0.92.0+1.20.4
+cloth_config_version=13.0.121
+mod_menu_version=9.0.0
 mixinextras_version=0.2.0


### PR DESCRIPTION
Not much changed between 20.2 and 20.4 so nothing more than updating `gradle.properties` is needed.
Tested all the configs as well, everything looks good.